### PR TITLE
fix: increased gasPrice and therefore maxFeePerGas

### DIFF
--- a/packages/harvester/test/BeefyHarvester.test.ts
+++ b/packages/harvester/test/BeefyHarvester.test.ts
@@ -96,7 +96,7 @@ describe("BeefyHarvester", () => {
 
   it("basic multiharvests", async () => {
     // set up gas price
-    const gasPrice = ethers.utils.parseUnits("5", "gwei");
+    const gasPrice = ethers.utils.parseUnits("100", "gwei");
     const upkeepOverrides: CallOverrides = {
       gasPrice,
     };


### PR DESCRIPTION
Fixes https://github.com/hackbg/chainlink-keeper-templates/issues/10 by increasing the gasPrice in BeefyHarvester.ts. 

Increasing the gas price also increases maxFeePerGas when it is not set specifically. I set it to 100 gwei so it's less likely to throw the same error again. 